### PR TITLE
Check for valid block

### DIFF
--- a/packages/migration_tool/src/PortlandLabs/Concrete5/MigrationTool/Publisher/Block/StandardPublisher.php
+++ b/packages/migration_tool/src/PortlandLabs/Concrete5/MigrationTool/Publisher/Block/StandardPublisher.php
@@ -36,15 +36,17 @@ class StandardPublisher implements PublisherInterface
                 }
             }
             // Now we import the OTHER records.
-            foreach ($records as $record) {
-                if (strcasecmp($record->getTable(), $bt->getController()->getBlockTypeDatabaseTable()) != 0) {
-                    $aar = new BlockRecord($record->getTable());
-                    $aar->bID = $b->getBlockID();
-                    foreach ($record->getData() as $key => $value) {
-                        $result = $inspector->inspect($value);
-                        $aar->{$key} = $result->getReplacedValue();
+            if ($b) {
+                foreach ($records as $record) {
+                    if (strcasecmp($record->getTable(), $bt->getController()->getBlockTypeDatabaseTable()) != 0) {
+                        $aar = new BlockRecord($record->getTable());
+                        $aar->bID = $b->getBlockID();
+                        foreach ($record->getData() as $key => $value) {
+                            $result = $inspector->inspect($value);
+                            $aar->{$key} = $result->getReplacedValue();
+                        }
+                        $aar->Save();
                     }
-                    $aar->Save();
                 }
             }
         } else {


### PR DESCRIPTION
I had to put this check in place to complete a migration.
Otherwise $b->getBlockID(); was throwing a function on a non-object error.

I couldn't track down why $b didn't exist, but this at least fixed the fatal error.