### PR TITLE
[Fix] LogList abstract class error

### DIFF
--- a/packages/migration_tool/src/PortlandLabs/Concrete5/MigrationTool/Publisher/Logger/LogList.php
+++ b/packages/migration_tool/src/PortlandLabs/Concrete5/MigrationTool/Publisher/Logger/LogList.php
@@ -9,7 +9,7 @@ use PortlandLabs\Concrete5\MigrationTool\Entity\Publisher\Log\Log;
 
 defined('C5_EXECUTE') or die("Access Denied.");
 
-class LogList extends EntityItemList
+abstract class LogList extends EntityItemList
 {
 
     protected $entityManager;


### PR DESCRIPTION
I got the following error with concrete5 latest version(8.1.0).
That's why I figured out this solution.

`An unexpected error occurred.
Class PortlandLabs\Concrete5\MigrationTool\Publisher\Logger\LogList contains 4 abstract methods and must therefore be declared abstract or implement the remaining methods (Concrete\Core\Search\ItemList\ItemList::executeSortBy, Concrete\Core\Search\ItemList\ItemList::executeGetResults, Concrete\Core\Search\ItemList\ItemList::debugStart, ...) `

![screen shot 2017-05-15 at 12 42 45 pm](https://cloud.githubusercontent.com/assets/2462951/26042098/4cadaf1c-396d-11e7-90de-7c3608c4846b.png)

**If a class has one or more abstract functions, it MUST be declared as an abstract class.**
Reference-
http://php.net/manual/en/language.oop5.abstract.php 