### PR TITLE
Add onDelete="CASCADE" for relations with core entities

### DIFF
--- a/packages/migration_tool/src/PortlandLabs/Concrete5/MigrationTool/Entity/Import/Batch.php
+++ b/packages/migration_tool/src/PortlandLabs/Concrete5/MigrationTool/Entity/Import/Batch.php
@@ -32,7 +32,7 @@ class Batch implements ValidatorInterface, BatchInterface
 
     /**
      * @ORM\ManyToOne(targetEntity="\Concrete\Core\Entity\Site\Site")
-     * @ORM\JoinColumn(name="siteID", referencedColumnName="siteID")
+     * @ORM\JoinColumn(name="siteID", referencedColumnName="siteID", onDelete="CASCADE")
      **/
     protected $site;
 

--- a/packages/migration_tool/src/PortlandLabs/Concrete5/MigrationTool/Entity/Publisher/Log/Log.php
+++ b/packages/migration_tool/src/PortlandLabs/Concrete5/MigrationTool/Entity/Publisher/Log/Log.php
@@ -49,13 +49,13 @@ class Log
 
     /**
      * @ORM\ManyToOne(targetEntity="\Concrete\Core\Entity\User\User")
-     * @ORM\JoinColumn(name="uID", referencedColumnName="uID")
+     * @ORM\JoinColumn(name="uID", referencedColumnName="uID", onDelete="CASCADE")
      **/
     protected $user;
 
     /**
      * @ORM\ManyToOne(targetEntity="\Concrete\Core\Entity\Site\Site")
-     * @ORM\JoinColumn(name="siteID", referencedColumnName="siteID")
+     * @ORM\JoinColumn(name="siteID", referencedColumnName="siteID", onDelete="CASCADE")
      **/
     protected $site;
 

--- a/packages/migration_tool/src/PortlandLabs/Concrete5/MigrationTool/Entity/Publisher/Log/Object/SocialLink.php
+++ b/packages/migration_tool/src/PortlandLabs/Concrete5/MigrationTool/Entity/Publisher/Log/Object/SocialLink.php
@@ -15,7 +15,7 @@ class SocialLink extends LoggableObject
 
     /**
      * @ORM\ManyToOne(targetEntity="\Concrete\Core\Entity\Sharing\SocialNetwork\Link")
-     * @ORM\JoinColumn(name="slID", referencedColumnName="slID")
+     * @ORM\JoinColumn(name="slID", referencedColumnName="slID", onDelete="CASCADE")
      **/
     protected $link;
 

--- a/packages/migration_tool/src/PortlandLabs/Concrete5/MigrationTool/Entity/Publisher/Log/Object/User.php
+++ b/packages/migration_tool/src/PortlandLabs/Concrete5/MigrationTool/Entity/Publisher/Log/Object/User.php
@@ -24,7 +24,7 @@ class User extends LoggableObject
 
     /**
      * @ORM\ManyToOne(targetEntity="\Concrete\Core\Entity\User\User")
-     * @ORM\JoinColumn(name="uID", referencedColumnName="uID")
+     * @ORM\JoinColumn(name="uID", referencedColumnName="uID", onDelete="CASCADE")
      **/
     public $coreUser;
 


### PR DESCRIPTION
We can't delete entities like User when Migration tool installed. Let's add `onDelete="CASCADE"` annotation for all relations with core entities.

This pull request fixes #32.

How to check schema diff with this pull request:

```
$ concrete/bin/concrete5 orm:schema-tool:update --dump-sql
```

Result:

```
ALTER TABLE MigrationImportBatches DROP FOREIGN KEY FK_27A214CF521D8435;
ALTER TABLE MigrationImportBatches ADD CONSTRAINT FK_27A214CF521D8435 FOREIGN KEY (siteID) REFERENCES Sites (siteID) ON DELETE CASCADE;
ALTER TABLE MigrationPublisherLogs DROP FOREIGN KEY FK_97ED2A48521D8435;
ALTER TABLE MigrationPublisherLogs DROP FOREIGN KEY FK_97ED2A48FD71026C;
ALTER TABLE MigrationPublisherLogs ADD CONSTRAINT FK_97ED2A48521D8435 FOREIGN KEY (siteID) REFERENCES Sites (siteID) ON DELETE CASCADE;
ALTER TABLE MigrationPublisherLogs ADD CONSTRAINT FK_97ED2A48FD71026C FOREIGN KEY (uID) REFERENCES Users (uID) ON DELETE CASCADE;
ALTER TABLE MigrationPublisherLogSocialLinkObjects DROP FOREIGN KEY FK_91E039D3490993EF;
ALTER TABLE MigrationPublisherLogSocialLinkObjects ADD CONSTRAINT FK_91E039D3490993EF FOREIGN KEY (slID) REFERENCES SocialLinks (slID) ON DELETE CASCADE;
ALTER TABLE MigrationPublisherLogUsers DROP FOREIGN KEY FK_62970051FD71026C;
ALTER TABLE MigrationPublisherLogUsers ADD CONSTRAINT FK_62970051FD71026C FOREIGN KEY (uID) REFERENCES Users (uID) ON DELETE CASCADE;
```

How to apply schema changes with this pull request:

```
$ concrete/bin/concrete5 orm:schema-tool:update --force
```