### PR TITLE
Ensure query only returns one result

### DIFF
--- a/packages/migration_tool/src/Concrete/Backup/ContentImporter/ValueInspector/Item/BatchPageItem.php
+++ b/packages/migration_tool/src/Concrete/Backup/ContentImporter/ValueInspector/Item/BatchPageItem.php
@@ -45,6 +45,7 @@ inner join e.log l where l.id = :log_id and p.cID > 0 and p.original_path = :ori
             );
             $query->setParameter('log_id', $log->getID());
             $query->setParameter('original_path', $cPath);
+            $query->setMaxResults(1);
             $loggedPage = $query->getOneOrNullResult();
             if (is_object($loggedPage)) {
                 return Page::getByID($loggedPage->getPublishedPageID(), 'ACTIVE');


### PR DESCRIPTION
From a recent migration we found that importing a batch would fail at some points with a NonUniqueResultException from Doctrine. This would throw up an error part-way through and stopped it from continuing.

This patch ensures that the doctrine query only returns on result, and in our case allowed the migration to complete without error.