### PR TITLE
Associate new attribute categories to existing attribute types

### DIFF
--- a/packages/migration_tool/src/PortlandLabs/Concrete5/MigrationTool/Exporter/Item/Type/AttributeKeyCategory.php
+++ b/packages/migration_tool/src/PortlandLabs/Concrete5/MigrationTool/Exporter/Item/Type/AttributeKeyCategory.php
@@ -25,6 +25,15 @@ class AttributeKeyCategory extends AbstractType
                 $cat->addAttribute('handle', $category->getAttributeKeyCategoryHandle());
                 $cat->addAttribute('allow-sets', $category->allowAttributeSets());
                 $cat->addAttribute('package', $category->getPackageHandle());
+                $attributeTypes = $category->getAttributeTypes();
+                if (!$attributeTypes->isEmpty()) {
+                    $xTypes = $cat->addChild('attributetypes');
+                    foreach ($attributeTypes as $attributeType) {
+                        $xType = $xTypes->addChild('attributetype');
+                        $xType->addAttribute('handle', $attributeType->getAttributeTypeHandle());
+                    }
+                }
+                
             }
         }
     }


### PR DESCRIPTION
Let's export the attribute types associated to the attribute categories (requires https://github.com/concrete5/concrete5/pull/6062 ).

I'm not sure about how to update `Importer\CIF\Element\AttributeKeyCategory`