### PR TITLE
Avoid "Parameter must be an array" error

### DIFF
--- a/packages/migration_tool/controllers/single_page/dashboard/system/migration/export.php
+++ b/packages/migration_tool/controllers/single_page/dashboard/system/migration/export.php
@@ -58,6 +58,7 @@ class Export extends DashboardSitePageController
         $batches = $r->findAll(array(), array('date' => 'desc'));
         $this->set('batches', $batches);
         $this->set('batchType', 'export');
+        $this->set('sites', $this->app->make('site')->getList());
         $this->set('batchEmptyMessage', t('You have not created any export batches.'));
         $this->render('/dashboard/system/migration/view_batches');
     }


### PR DESCRIPTION
A screen capture of the error

![screencapture-concrete5-test-index-php-dashboard-system-migration-export-1516756073297](https://user-images.githubusercontent.com/514294/35311380-9374f4a6-00f9-11e8-85cc-4d4b150e3dd6.png)

