### PR TITLE
Add PageListImporter with defaults

### DIFF
--- a/packages/migration_tool/src/PortlandLabs/Concrete5/MigrationTool/Importer/CIF/Block/Manager.php
+++ b/packages/migration_tool/src/PortlandLabs/Concrete5/MigrationTool/Importer/CIF/Block/Manager.php
@@ -53,4 +53,8 @@ class Manager extends CoreManager
         return new ImageSliderImporter();
     }
 
+    public function createPageListDriver()
+    {
+        return new PageListImporter();
+    }
 }

--- a/packages/migration_tool/src/PortlandLabs/Concrete5/MigrationTool/Importer/CIF/Block/PageListImporter.php
+++ b/packages/migration_tool/src/PortlandLabs/Concrete5/MigrationTool/Importer/CIF/Block/PageListImporter.php
@@ -1,0 +1,25 @@
+<?php
+namespace PortlandLabs\Concrete5\MigrationTool\Importer\CIF\Block;
+
+defined('C5_EXECUTE') or die("Access Denied.");
+
+class PageListImporter extends StandardImporter
+{
+    public function parse(\SimpleXMLElement $node)
+    {
+        $value = parent::parse($node);
+
+        foreach ($value->getRecords() as $record) {
+            $data = $record->getData();
+            if (!isset($data['includeDescription'])) {
+                $data['includeDescription'] = true;
+            }
+            if (!isset($data['includeName'])) {
+                $data['includeName'] = true;
+            }
+            $record->setData($data);
+        }
+
+        return $value;
+    }
+}


### PR DESCRIPTION
When importing a Page List block from concrete5 5.6.4.0, I noticed the new options "Include Name" and "Include Page Description" are always turned off and the Page List block appears empty in version 8.3.2 after the import.

Looking at the code of the block, the default values are only set in the add view:

https://github.com/concrete5/concrete5/blob/fa1ab2d331623d545968b8e1bec0dd5ef91f04cd/concrete/blocks/page_list/controller.php#L236-L237

This pull request sets them during the import of a Page List block. No idea if this is the right way to implement it, but it works.