### PR TITLE
Create missing rssHandle

### DIFF
--- a/packages/migration_tool/src/PortlandLabs/Concrete5/MigrationTool/Importer/CIF/Block/PageListImporter.php
+++ b/packages/migration_tool/src/PortlandLabs/Concrete5/MigrationTool/Importer/CIF/Block/PageListImporter.php
@@ -9,6 +9,8 @@ class PageListImporter extends StandardImporter
     {
         $value = parent::parse($node);
 
+        $text = \Core::make('helper/text');
+
         foreach ($value->getRecords() as $record) {
             $data = $record->getData();
             if (!isset($data['includeDescription'])) {
@@ -16,6 +18,11 @@ class PageListImporter extends StandardImporter
             }
             if (!isset($data['includeName'])) {
                 $data['includeName'] = true;
+            }
+            if (isset($data['rss']) && $data['rss']) {
+                if (!isset($data['rssHandle'])) {
+                    $data['rssHandle'] = $text->urlify($data['rssTitle']);
+                }
             }
             $record->setData($data);
         }


### PR DESCRIPTION
`rssHandle` didn't exist in older concrete5 versions and leads to an SQL exception while importing, because `pfHandle` in the database table `PageFeeds` cannot be `NULL`.