### PR TITLE
Stop the importer erroring out while validating ImageSlider blocks in unknown areas

### DIFF
--- a/packages/migration_tool/src/PortlandLabs/Concrete5/MigrationTool/Batch/Validator/Block/ImageSliderValidator.php
+++ b/packages/migration_tool/src/PortlandLabs/Concrete5/MigrationTool/Batch/Validator/Block/ImageSliderValidator.php
@@ -22,8 +22,13 @@ class ImageSliderValidator implements ItemValidatorInterface
         if ($record) {
             $data = $record->getData();
             if (isset($data['fsID']) && $data['fsID'] > 0) {
-                $page = $value->getBlock()->getArea()->getPage();
-                $messages->add(new Message(t('Slideshow block on page "%s" uses a file set for display. This will not migrate properly.', $page->getName())));
+                $pageName = 'Unknown Page';
+
+                if ($area = $value->getBlock()->getArea()) {
+                    $pageName = $area->getPage()->getName();
+                }
+                
+                $messages->add(new Message(t('Slideshow block on page "%s" uses a file set for display. This will not migrate properly.', $pageName)));
             }
         }
 


### PR DESCRIPTION
While importing from a legacy site, I got a 500 error while setting up a batch,  specifically within the  'stacks and areas' area.

Turned out to be because the [ImageSliderValidator can't figure out the name of the page](https://github.com/concrete5/addon_migration_tool/blob/490beca0dfaaa33b2af69a38fece017284947d80/packages/migration_tool/src/PortlandLabs/Concrete5/MigrationTool/Batch/Validator/Block/ImageSliderValidator.php#L25) while trying to report a validation error. 

I've simply made it return 'Unkown Page' for these instances.