### PR TITLE
Add support for WP media files

### DIFF
--- a/packages/migration_tool/src/PortlandLabs/Concrete5/MigrationTool/Importer/Wordpress/ElementParserInterface.php
+++ b/packages/migration_tool/src/PortlandLabs/Concrete5/MigrationTool/Importer/Wordpress/ElementParserInterface.php
@@ -5,5 +5,5 @@ defined('C5_EXECUTE') or die("Access Denied.");
 
 interface ElementParserInterface
 {
-    public function getObjectCollection(\SimpleXMLElement $xml, array $namespaces);
+    public function getObjectCollection(\SimpleXMLElement $xml, array $namespaces, $batch);
 }

--- a/packages/migration_tool/src/PortlandLabs/Concrete5/MigrationTool/Importer/Wordpress/WordpressParser.php
+++ b/packages/migration_tool/src/PortlandLabs/Concrete5/MigrationTool/Importer/Wordpress/WordpressParser.php
@@ -53,7 +53,7 @@ class WordpressParser implements FileParserInterface
 //        $simplexml = simplexml_load_file($file);
 
         foreach ($manager->getDrivers() as $driver) {
-            $collection = $driver->getObjectCollection($this->wxr, $this->namespaces);
+            $collection = $driver->getObjectCollection($this->wxr, $this->namespaces, $batch);
             if ($collection) {
                 if (!($collection instanceof ObjectCollection)) {
                     throw new \RuntimeException(t('Driver %s getObjectCollection did not return an object of the ObjectCollection type', get_class($driver)));


### PR DESCRIPTION
Adds support for files when importing from Wordpress. There is for sure lots of room for improvement here. However at least some basic functionality is better than nothing. The biggest issue right now is that computation resources grow exponentially with the number of files and linear with the number of pages.