### PR TITLE
add include-system-pages filter

### DIFF
--- a/packages/migration_tool/elements/export/search/page.php
+++ b/packages/migration_tool/elements/export/search/page.php
@@ -31,3 +31,9 @@ foreach ($list as $type) {
     <label class="control-label"><?=t('Filter by Page Type')?></label>
     <?=$form->select('ptID', $pagetypes)?>
 </div>
+
+<div class="form-group">
+	<div class="checkbox">
+    	<label> <?php echo $form->checkbox('includeSystemPages', 1, $includeSystemPages);  ?><?=t('Include System Pages'); ?></label>
+	</div>
+</div>

--- a/packages/migration_tool/src/PortlandLabs/Concrete5/MigrationTool/Exporter/Item/Type/Page.php
+++ b/packages/migration_tool/src/PortlandLabs/Concrete5/MigrationTool/Exporter/Item/Type/Page.php
@@ -32,6 +32,8 @@ class Page extends SinglePage
         $ptID = $query['ptID'];
         $startingPoint = intval($query['startingPoint']);
         $datetime = \Core::make('helper/form/date_time')->translate('datetime', $query);
+        $includeSystemPages = $query['includeSystemPages'];
+
         $pl->ignorePermissions();
         if ($startingPoint) {
             $parent = \Page::getByID($startingPoint, 'ACTIVE');
@@ -40,13 +42,16 @@ class Page extends SinglePage
         if ($datetime) {
             $pl->filterByPublicDate($datetime, '>=');
         }
-
         if ($ptID) {
             $pl->filterByPageTypeID($ptID);
         }
         if ($keywords) {
             $pl->filterByKeywords($keywords);
         }
+        if($includeSystemPages) {
+            $pl->includeSystemPages();
+        }    
+
         $pl->setItemsPerPage(1000);
         $results = $pl->getResults();
         $items = array();


### PR DESCRIPTION
This PR adds an `Include System Pages` checkbox when adding pages to a Batch. 
The new checkbox can be alternatively defined as `Exclude System Pages`. From my point of view and as someone who uses this add-on to export theme pages, the `Include System Pages` makes more sense. But if you think the later would cover more use cases, let me know, and I would swap it with `Exclude System Pages`.

![Screenshot_2020-01-24-Add-To-Batch](https://user-images.githubusercontent.com/7886999/73073883-92c7b200-3ecd-11ea-9ada-2c7f80b45a88.jpg)
