### PR TITLE
Avoid setting attributes to not found page

### DIFF
--- a/packages/migration_tool/src/PortlandLabs/Concrete5/MigrationTool/Publisher/Routine/PublishPageContentRoutineAction.php
+++ b/packages/migration_tool/src/PortlandLabs/Concrete5/MigrationTool/Publisher/Routine/PublishPageContentRoutineAction.php
@@ -14,14 +14,16 @@ class PublishPageContentRoutineAction extends AbstractPageAction
         $page = $this->page;
         $concretePage = $this->getPageByPath($batch, $page->getBatchPath());
 
-        foreach ($page->attributes as $attribute) {
-            $ak = $this->getTargetItem($batch, 'page_attribute', $attribute->getAttribute()->getHandle());
-            if (is_object($ak)) {
-                $logger->logPublishStarted($attribute);
-                $value = $attribute->getAttribute()->getAttributeValue();
-                $publisher = $value->getPublisher();
-                $publisher->publish($batch, $ak, $concretePage, $value);
-                $logger->logPublishComplete($attribute);
+        if (is_object($concretePage) && !$concretePage->isError()) {
+            foreach ($page->attributes as $attribute) {
+                $ak = $this->getTargetItem($batch, 'page_attribute', $attribute->getAttribute()->getHandle());
+                if (is_object($ak)) {
+                    $logger->logPublishStarted($attribute);
+                    $value = $attribute->getAttribute()->getAttributeValue();
+                    $publisher = $value->getPublisher();
+                    $publisher->publish($batch, $ak, $concretePage, $value);
+                    $logger->logPublishComplete($attribute);
+                }
             }
         }
 


### PR DESCRIPTION
I got an error when importing pages that have an invalid page path.
Let's check whether or not we can get the page correctly before setting attributes.